### PR TITLE
Feature/setup api and data access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,39 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Common IntelliJ Platform excludes (from https://raw.githubusercontent.com/JetBrains/resharper-rider-samples/master/.gitignore)
+
+# User specific
+**/.idea/**/workspace.xml
+**/.idea/**/tasks.xml
+**/.idea/shelf/*
+**/.idea/dictionaries
+**/.idea/httpRequests/
+
+# Sensitive or high-churn files
+**/.idea/**/dataSources/
+**/.idea/**/dataSources.ids
+**/.idea/**/dataSources.xml
+**/.idea/**/dataSources.local.xml
+**/.idea/**/sqlDataSources.xml
+**/.idea/**/dynamic.xml
+
+# Rider
+# Rider auto-generates .iml files, and contentModel.xml
+**/.idea/**/*.iml
+**/.idea/**/contentModel.xml
+**/.idea/**/modules.xml
+.idea/
+
+*.suo
+*.user
+.vs/
+[Bb]in/
+[Oo]bj/
+_UpgradeReport_Files/
+[Pp]ackages/
+
+Thumbs.db
+Desktop.ini
+.DS_Store

--- a/DocumentDataAPI/DocumentDataAPI.sln
+++ b/DocumentDataAPI/DocumentDataAPI.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentDataAPI", "DocumentDataAPI\DocumentDataAPI.csproj", "{54C47CAF-5A3C-487D-BEFD-4EECAAB15D7C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentDataAPITests", "DocumentDataAPITests\DocumentDataAPITests.csproj", "{7869A09F-13B7-4940-8BE5-0A29BF81C024}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{54C47CAF-5A3C-487D-BEFD-4EECAAB15D7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54C47CAF-5A3C-487D-BEFD-4EECAAB15D7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54C47CAF-5A3C-487D-BEFD-4EECAAB15D7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54C47CAF-5A3C-487D-BEFD-4EECAAB15D7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7869A09F-13B7-4940-8BE5-0A29BF81C024}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7869A09F-13B7-4940-8BE5-0A29BF81C024}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7869A09F-13B7-4940-8BE5-0A29BF81C024}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7869A09F-13B7-4940-8BE5-0A29BF81C024}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/WeatherForecastController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/WeatherForecastController.cs
@@ -22,11 +22,11 @@ public class WeatherForecastController : ControllerBase
     public IEnumerable<WeatherForecast> Get()
     {
         return Enumerable.Range(1, 5).Select(index => new WeatherForecast
-            {
-                Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
-                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
-            })
-            .ToArray();
+        {
+            Date = DateTime.Now.AddDays(index),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
     }
 }

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/WeatherForecastController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/WeatherForecastController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace DocumentDataAPI.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+    }
+}

--- a/DocumentDataAPI/DocumentDataAPI/Data/Deployment/DatabaseDeployHelper.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Deployment/DatabaseDeployHelper.cs
@@ -1,0 +1,39 @@
+using System.Data;
+using Dapper;
+using DocumentDataAPI.Options;
+using Npgsql;
+
+namespace DocumentDataAPI.Data.Deployment;
+
+public class DatabaseDeployHelper
+{
+    private readonly DatabaseOptions _databaseOptions;
+
+    public DatabaseDeployHelper(DatabaseOptions databaseOptions)
+    {
+        _databaseOptions = databaseOptions;
+    }
+
+    public void Deploy()
+    {
+        string scriptPath = Path.Combine(Environment.CurrentDirectory, @"Data/Deployment/deploy_schema.sql");
+        Console.WriteLine("Executing script: " + scriptPath);
+        string[] parameters = { _databaseOptions.Database, _databaseOptions.Schema };
+        string script = ParseScript(scriptPath, parameters);
+
+        using IDbConnection db = new NpgsqlConnection(_databaseOptions.ConnectionString);
+        db.Execute(script);
+    }
+
+    /// <summary>
+    /// Reads a SQL script file and inserts docker database- and schema name parameters into correct locations for deployment.
+    /// </summary>
+    /// <param name="scriptPath">File path to SQL script.</param>
+    /// <param name="parameters">Array of docker database- and schema name parameters.</param>
+    /// <returns>The parsed file as a string, containing the SQL script with replaced parameters.</returns>
+    private string ParseScript(string scriptPath, string[] parameters)
+    {
+        string script = File.ReadAllText(scriptPath);
+        return script.Replace("${db}", parameters[0]).Replace("${schema}", parameters[1]);
+    }
+}

--- a/DocumentDataAPI/DocumentDataAPI/Data/Deployment/deploy_schema.sql
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Deployment/deploy_schema.sql
@@ -1,0 +1,36 @@
+drop schema if exists ${schema} cascade;
+
+create schema ${schema};
+
+create table ${schema}.sources (
+    id      serial          primary key,
+    name    varchar(100)    not null
+);
+
+create table ${schema}.documents (
+    id          bigint       primary key,
+    sources_id  integer      not null,
+    title       varchar(400) not null,
+    path        varchar(400) not null,
+    summary     text         not null,
+    date        timestamp    not null,
+    author      varchar(200) not null,
+    total_words integer      not null,
+    constraint fk_sources foreign key (sources_id) references ${schema}.sources(id)
+);
+
+create table ${schema}.word_ratios (
+    documents_id  bigint  not null,
+    word          varchar(100) not null,
+    amount        integer not null,
+    percent       real not null,
+    rank          integer not null,
+    constraint fk_documents foreign key (documents_id) references ${schema}.documents(id),
+    constraint pk_files_id_word primary key (documents_id, word)
+);
+
+create table ${schema}.document_contents (
+    documents_id    bigint not null,
+    content         text not null,
+    constraint fk_documents foreign key (documents_id) references ${schema}.documents(id)
+);

--- a/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
+++ b/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
+      <UserSecretsId>ef22c319-df7d-44e3-9d95-e57c8109ef4b</UserSecretsId>
+  </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0-rc.1.22426.10" />
         <PackageReference Include="Npgsql" Version="7.0.0-rc.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     </ItemGroup>

--- a/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
+++ b/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
@@ -7,11 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Dapper" Version="2.0.123" />
+        <PackageReference Include="Npgsql" Version="7.0.0-rc.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Data" />
     </ItemGroup>
 
 </Project>

--- a/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
+++ b/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Data" />
+    </ItemGroup>
+
+</Project>

--- a/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
+++ b/DocumentDataAPI/DocumentDataAPI/DocumentDataAPI.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0-rc.1.22426.10" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
         <PackageReference Include="Npgsql" Version="7.0.0-rc.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     </ItemGroup>

--- a/DocumentDataAPI/DocumentDataAPI/Models/WeatherForecast.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Models/WeatherForecast.cs
@@ -6,7 +6,7 @@ public class WeatherForecast
 
     public int TemperatureC { get; set; }
 
-    public int TemperatureF => 32 + (int) (TemperatureC / 0.5556);
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
     public string? Summary { get; set; }
 }

--- a/DocumentDataAPI/DocumentDataAPI/Models/WeatherForecast.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Models/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace DocumentDataAPI;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int) (TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
@@ -8,7 +8,7 @@ public class DatabaseOptions
 {
     public const string Key = "Database";
     public string Host { get; set; } = string.Empty;
-    public int Port { get; set; } = 0;
+    public int Port { get; set; }
     public string Database { get; set; } = string.Empty;
     public string Schema { get; set; } = string.Empty;
     public string Username { get; set; } = string.Empty;

--- a/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
@@ -13,7 +13,7 @@ public class DatabaseOptions
     public string Schema { get; set; } = string.Empty;
     public string Username { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// Builds a connection string from the database options.
     /// For example: "UserID=postgres;Password=postgres;Host=localhost;Port=5432;Database=myDatabase;SearchPath=mySchema"
@@ -23,7 +23,7 @@ public class DatabaseOptions
     /// This is specific to PostgreSQL, and may be different with other database providers.
     /// See https://www.connectionstrings.com/db2-net-data-provider-db2connection/specifying-schema/ for more information.
     /// </remarks>
-    public string ConnectionString => 
+    public string ConnectionString =>
         "UserID=" + Username + ";" +
         "Password=" + Password + ";" +
         "Host=" + Host + ";" +

--- a/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
@@ -1,0 +1,34 @@
+namespace DocumentDataAPI.Options;
+
+/// <summary>
+/// Strongly typed options class for the "Database" section in appsettings.
+/// Based on the options pattern (https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-6.0)
+/// </summary>
+public class DatabaseOptions
+{
+    public const string Key = "Database";
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; } = 0;
+    public string Database { get; set; } = string.Empty;
+    public string Schema { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Builds a connection string from the database options.
+    /// For example: "UserID=postgres;Password=postgres;Host=localhost;Port=5432;Database=myDatabase;SearchPath=mySchema"
+    /// </summary>
+    /// <returns>String used to connect to the database.</returns>
+    /// <remarks>The SearchPath property specifies which schema is used by default when executing queries on the database.
+    /// This is specific to PostgreSQL, and may be different with other database providers.
+    /// See https://www.connectionstrings.com/db2-net-data-provider-db2connection/specifying-schema/ for more information.
+    /// </remarks>
+    public string ConnectionString => 
+        "UserID=" + Username + ";" +
+        "Password=" + Password + ";" +
+        "Host=" + Host + ";" +
+        "Port=" + Port + ";" +
+        "Database=" + Database + ";" +
+        "SearchPath=" + Schema + ";"
+        ;
+}

--- a/DocumentDataAPI/DocumentDataAPI/Program.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Program.cs
@@ -1,0 +1,25 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/DocumentDataAPI/DocumentDataAPI/Program.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Program.cs
@@ -1,3 +1,6 @@
+using DocumentDataAPI.Data.Deployment;
+using DocumentDataAPI.Options;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -8,6 +11,17 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+
+// Check for "deploy=true" command-line argument
+if (app.Configuration.GetValue<bool>("deploy"))
+{
+    var options = app.Configuration.GetSection(DatabaseOptions.Key).Get<DatabaseOptions>();
+    var deployHelper = new DatabaseDeployHelper(options);
+    Console.WriteLine($"Deploying to schema: {options.Database}.{options.Schema}");
+    deployHelper.Deploy();
+    Console.WriteLine("Finished!");
+    return;
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/DocumentDataAPI/DocumentDataAPI/Properties/launchSettings.json
+++ b/DocumentDataAPI/DocumentDataAPI/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:14945",
+      "sslPort": 44321
+    }
+  },
+  "profiles": {
+    "DocumentDataAPI": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7064;http://localhost:5064",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/DocumentDataAPI/DocumentDataAPI/Properties/launchSettings.json
+++ b/DocumentDataAPI/DocumentDataAPI/Properties/launchSettings.json
@@ -26,6 +26,13 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "Deploy database": {
+      "commandName": "Project",
+      "commandLineArgs": "deploy=true",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/DocumentDataAPI/DocumentDataAPI/appsettings.Development.json
+++ b/DocumentDataAPI/DocumentDataAPI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/DocumentDataAPI/DocumentDataAPI/appsettings.json
+++ b/DocumentDataAPI/DocumentDataAPI/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/DocumentDataAPI/DocumentDataAPI/appsettings.json
+++ b/DocumentDataAPI/DocumentDataAPI/appsettings.json
@@ -5,5 +5,13 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Database": {
+    "Host": "localhost",
+    "Port": 5432,
+    "Database": "[INSERT DATABASE]",
+    "Schema": "document_data",
+    "Username": "[INSERT USERNAME]",
+    "Password": "[INSERT PASSWORD]"
+  }
 }

--- a/DocumentDataAPI/DocumentDataAPITests/DocumentDataAPITests.csproj
+++ b/DocumentDataAPI/DocumentDataAPITests/DocumentDataAPITests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/DocumentDataAPI/DocumentDataAPITests/Usings.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
Der er sat en ny WebAPI op, der fungerer på samme måde som den gamle (WordCountAPI) _med_ vores ændringer.
Man specificerer sine lokale indstillinger i UserSecrets, og så kan man køre "Deploy database" for at få schemaet op og køre på en lokal PostgreSQL database.

Efter dette PR kan vi smide de models og controllers vi har arbejdet på ind, og bygge videre på det.
Man kan også smide APIen i en docker container på et senere tidspunkt, hvis vi ønsker det.