### PR TITLE
Feature/consistent controller endpoints

### DIFF
--- a/DocumentDataAPI/DocumentDataAPI/Controllers/WordRatioController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/WordRatioController.cs
@@ -18,6 +18,12 @@ public class WordRatioController : ControllerBase
         _repository = repository;
     }
 
+    /// <summary>
+    /// Retrieves all word ratios.
+    /// </summary>
+    /// <response code="200">Success: A list of word ratios.</response>
+    /// <response code="204">No Content: Nothing is returned.</response>
+    /// <response code="500">Internal Server Error: A <see cref="ProblemDetails"/> describing the error.</response>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -37,6 +43,12 @@ public class WordRatioController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Retrieves a word ratio with a specific word and document.
+    /// </summary>
+    /// <response code="200">Success: The word ratio.</response>
+    /// <response code="204">No Content: Nothing is returned.</response>
+    /// <response code="500">Internal Server Error: A <see cref="ProblemDetails"/> describing the error.</response>
     [HttpGet]
     [Route("documents/{documentId:int}/{word}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -57,6 +69,12 @@ public class WordRatioController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Retrieves all word ratios for a specific document.
+    /// </summary>
+    /// <response code="200">Success: All word ratios for the specified document.</response>
+    /// <response code="204">No Content: Nothing is returned.</response>
+    /// <response code="500">Internal Server Error: A <see cref="ProblemDetails"/> describing the error.</response>
     [HttpGet]
     [Route("documents/{documentId:int}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -77,6 +95,12 @@ public class WordRatioController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Retrieves all word ratios that contain a word in the given <paramref name="wordListString"/>, which is a comma-separated string of words.
+    /// </summary>
+    /// <response code="200">Success: All word ratios with the specified word.</response>
+    /// <response code="204">No Content: Nothing is returned.</response>
+    /// <response code="500">Internal Server Error: A <see cref="ProblemDetails"/> describing the error.</response>
     [HttpGet]
     [Route("words/{wordListString}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -98,6 +122,12 @@ public class WordRatioController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Deletes the word ratio that is given in the request body.
+    /// </summary>
+    /// <response code="200">Success: The deleted word ratio.</response>
+    /// <response code="204">No Content: Nothing is returned.</response>
+    /// <response code="500">Internal Server Error: A <see cref="ProblemDetails"/> describing the error.</response>
     [HttpDelete]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -118,6 +148,12 @@ public class WordRatioController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Updates the values of the word ratio that is given in the request body.
+    /// </summary>
+    /// <response code="200">Success: The updated word ratio.</response>
+    /// <response code="204">No Content: Nothing is returned.</response>
+    /// <response code="500">Internal Server Error: A <see cref="ProblemDetails"/> describing the error.</response>
     [HttpPost]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -138,6 +174,12 @@ public class WordRatioController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Inserts the given list of word ratios in the database.
+    /// </summary>
+    /// <response code="200">Success: The number of rows inserted.</response>
+    /// <response code="204">No Content: Nothing is returned.</response>
+    /// <response code="500">Internal Server Error: A <see cref="ProblemDetails"/> describing the error.</response>
     [HttpPut]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/WordRatioController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/WordRatioController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace DocumentDataAPI.Controllers;
 
 [ApiController]
-[Route("[controller]")]
+[Route(RoutePrefixHelper.Prefix + "/word-ratios")]
 public class WordRatioController : ControllerBase
 {
     private readonly IWordRatioRepository _repository;
@@ -19,7 +19,6 @@ public class WordRatioController : ControllerBase
     }
 
     [HttpGet]
-    [Route("GetAll/")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -38,9 +37,8 @@ public class WordRatioController : ControllerBase
         }
     }
 
-
     [HttpGet]
-    [Route("GetByDocumentIDAndWord/{id:int}/{word}")]
+    [Route("documents/{documentId:int}/{word}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -60,7 +58,7 @@ public class WordRatioController : ControllerBase
     }
 
     [HttpGet]
-    [Route("GetByDocumentId/{id:int}")]
+    [Route("documents/{documentId:int}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -80,35 +78,16 @@ public class WordRatioController : ControllerBase
     }
 
     [HttpGet]
-    [Route("GetByWord/{word}")]
+    [Route("words/{wordListString}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public ActionResult<IEnumerable<WordRatioModel>> GetByWord(string word)
+    public ActionResult<IEnumerable<WordRatioModel>> GetByWord(string wordListString)
     {
+        List<string> wordList = wordListString.Split(',').ToList();
         try
         {
-            IEnumerable<WordRatioModel> result = _repository.GetByWord(word);
-            return result.Any()
-                ? Ok(result)
-                : NoContent();
-        }
-        catch (DbException e)
-        {
-            return Problem(e.Message);
-        }
-    }
-
-    [HttpGet]
-    [Route("GetByWords/{wordlist}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public ActionResult<int> GetByWords(IEnumerable<string> wordlist)
-    {
-        try
-        {
-            IEnumerable<WordRatioModel> result = _repository.GetByWords(wordlist);
+            IEnumerable<WordRatioModel> result = _repository.GetByWords(wordList);
             return result.Any()
                 ? Ok(result)
                 : NoContent();
@@ -120,11 +99,11 @@ public class WordRatioController : ControllerBase
     }
 
     [HttpDelete]
-    [Route("DeleteWordRatio/{wordRatio}")]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public ActionResult<int> DeleteWordRatio(WordRatioModel wordRatio)
+    public ActionResult<int> DeleteWordRatio([FromBody] WordRatioModel wordRatio)
     {
         try
         {
@@ -139,13 +118,12 @@ public class WordRatioController : ControllerBase
         }
     }
 
-
     [HttpPost]
-    [Route("UpdateWordRatio/{wordratio}")]
+    [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public ActionResult<int> UpdateWordRatio(WordRatioModel wordRatio)
+    public ActionResult<int> UpdateWordRatio([FromBody] WordRatioModel wordRatio)
     {
         try
         {
@@ -160,30 +138,7 @@ public class WordRatioController : ControllerBase
         }
     }
 
-
     [HttpPut]
-    [Route("PutWordRatio")]
-    [Consumes(MediaTypeNames.Application.Json)]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public ActionResult<int> PutWordRatio([FromBody] WordRatioModel wordRatio)
-    {
-        try
-        {
-            int result = _repository.Add(wordRatio);
-            return result == 1
-                ? Ok(result)
-                : NoContent();
-        }
-        catch (DbException e)
-        {
-            return Problem(e.Message);
-        }
-    }
-
-    [HttpPut]
-    [Route("PutWordRatios")]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentContentRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentContentRepository.cs
@@ -2,6 +2,7 @@ using System.Data;
 using Dapper;
 using Dapper.Transaction;
 using DocumentDataAPI.Data.Repositories.Helpers;
+using DocumentDataAPI.Exceptions;
 using DocumentDataAPI.Models;
 
 namespace DocumentDataAPI.Data.Repositories;
@@ -93,7 +94,7 @@ public class NpgDocumentContentRepository : IDocumentContentRepository
 
             if (rowsAffected != models.Count)
             {
-                throw new Exception("Mismatch!");
+                throw new RowsAffectedMismatchException();
             }
             transaction.Commit();
         }

--- a/DocumentDataAPI/DocumentDataAPI/Exceptions/RowsAffectedMismatch.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Exceptions/RowsAffectedMismatch.cs
@@ -7,7 +7,7 @@ namespace DocumentDataAPI.Exceptions;
 [Serializable]
 public class RowsAffectedMismatchException : Exception
 {
-    public RowsAffectedMismatchException()
+    public RowsAffectedMismatchException() : this("Not all rows were inserted due to an unknown error.")
     {
     }
 


### PR DESCRIPTION
Har gjort routes i `WordRatioController` consistent ift. de andre controllers. Den ene `PUT` metode er fjernet, da der lige så godt kan være én metode der tager en liste af `WordRatios` (listen kan jo godt indeholde 1 element).

I lidt samme stil er `GET` for ét word merget sammen med `GET` for en streng af words der er adskildt med komma. For hvis man vil søge efter ét ord, så giver man den bare ét ord som input uden komma.

Derudover er der tilføjet dokumentation til disse endpoints.

EDIT: Bemærk også at de metoder, der tager mod en `WordRatioModel` som parameter i routen, er ændret til at modtage en `WordRatioModel` fra dens request body i stedet. (Det giver ikke mening at sende et json-objekt i et URL)