### PR TITLE
added build.yaml action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  pull_request:
+    branches: 
+      - master
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v3.0.2
+      with:
+        dotnet-version: 6.x
+    - name: Install dependencies
+      run: dotnet restore
+      working-directory: DocumentDataAPI/
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+      working-directory: DocumentDataAPI/

--- a/DocumentDataAPI/DocumentDataAPITests/DocumentDataAPITests.csproj
+++ b/DocumentDataAPI/DocumentDataAPITests/DocumentDataAPITests.csproj
@@ -30,16 +30,8 @@
 
     <ItemGroup>
       <None Update="appsettings.Tests.local.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="appsettings.Tests.local.json">
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      </Content>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/DocumentDataAPI/DocumentDataAPITests/TestHelper.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/TestHelper.cs
@@ -20,7 +20,8 @@ public static class TestHelper
             if (!_isInitialized)
             {
                 _configuration = new ConfigurationBuilder()
-                    .AddJsonFile(Path.Combine(Environment.CurrentDirectory, "appsettings.Tests.local.json"), false)
+                    .AddJsonFile(Path.Combine(Environment.CurrentDirectory, "appsettings.Tests.local.json"), true)
+                    .AddEnvironmentVariables()
                     .Build();
                 // Set up Dapper mappers
                 FluentMapper.Initialize(config =>


### PR DESCRIPTION
Har tilføjet en build action der simpelthen bygger alle projekter i vores solution, når laves PR til dev og master.
Ville også have tilføjet at den skulle køre tests derefter, men det fungerer ikke rigtig med integration tests (det kræver at vi har en test database kørende et sted, som vores github action kan connecte til. Så måske kan det tilføjes senere)

Bemærk at `appsettings.Tests.local.json` er blevet gjort optional, da den ellers stoppede denne build action. Derudover er environment variables tilføjet, så man i fremtiden f.eks. kan smide nogle environment variables ind via github secrets, der så kan forbinde til en test database.