### PR TITLE
Removed command timeout on TF-IDF update query

### DIFF
--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgWordRelevanceRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgWordRelevanceRepository.cs
@@ -34,7 +34,7 @@ namespace DocumentDataAPI.Data.Repositories
                             where 1 = 1;";
             using IDbConnection con = _connectionFactory.CreateConnection();
 
-            return await con.ExecuteAsync(script);
+            return await con.ExecuteAsync(script, commandTimeout: 0);
         }
     }
 }


### PR DESCRIPTION
Default-værdien for `commandTimeout` er ikke nok til at udføre TF-IDF update querien, så hvis man forsøger at bruge dette endpoint på serveren, så fejler den efter _x_ sekunder pga. det timeout.

Jeg synes ikke det giver mening at give den en arbitrær begrænsning, da vi ikke kan vide hvor længe det reelt kommer til at tage. I stedet er den sat til 0, hvilket betyder at den vil fortsætte indtil den er færdig.