### PR TITLE
Fix default limits in controllers

### DIFF
--- a/DocumentDataAPI/DocumentDataAPI/Controllers/CategoryController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/CategoryController.cs
@@ -32,7 +32,7 @@ public class CategoryController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<CategoryModel>>> GetAll(int? limit, int? offset)
+    public async Task<ActionResult<IEnumerable<CategoryModel>>> GetAll(int? limit = 100, int? offset = null)
     {
         try
         {

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/DocumentContentController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/DocumentContentController.cs
@@ -31,7 +31,7 @@ public class DocumentContentController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<DocumentContentModel>>> GetAll(int? limit, int? offset)
+    public async Task<ActionResult<IEnumerable<DocumentContentModel>>> GetAll(int? limit = 100, int? offset = null)
     {
         try
         {

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/DocumentController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/DocumentController.cs
@@ -59,11 +59,10 @@ public class DocumentController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<DocumentModel>>> GetAll([FromQuery] List<long> sourceIds, [FromQuery] List<string> authors, [FromQuery] List<int> categoryIds, DateTime? beforeDate, DateTime? afterDate, int? limit, int? offset)
+    public async Task<ActionResult<IEnumerable<DocumentModel>>> GetAll([FromQuery] List<long> sourceIds, [FromQuery] List<string> authors, [FromQuery] List<int> categoryIds, DateTime? beforeDate, DateTime? afterDate, int? limit = 100, int? offset = null)
     {
         try
         {
-            limit ??= 100;
             DocumentSearchParameters parameters = new DocumentSearchParameters();
             if (sourceIds.Any()) parameters.AddSources(sourceIds);
             if (authors.Any()) parameters.AddAuthors(authors);

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/SearchController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/SearchController.cs
@@ -41,7 +41,7 @@ public class SearchController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<SearchResponseModel>>> Get(string words, [FromQuery] List<long> sourceIds, [FromQuery] List<string> authors, [FromQuery] List<int> categoryIds, DateTime? beforeDate, DateTime? afterDate, int? limit, int? offset)
+    public async Task<ActionResult<IEnumerable<SearchResponseModel>>> Get(string words, [FromQuery] List<long> sourceIds, [FromQuery] List<string> authors, [FromQuery] List<int> categoryIds, DateTime? beforeDate, DateTime? afterDate, int? limit = 100, int? offset = null)
     {
         try
         {

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/SourceController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/SourceController.cs
@@ -31,7 +31,7 @@ public class SourceController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<SourceModel>>> GetAll(int? limit, int? offset)
+    public async Task<ActionResult<IEnumerable<SourceModel>>> GetAll(int? limit = 100, int? offset = null)
     {
         try
         {

--- a/DocumentDataAPI/DocumentDataAPI/Controllers/WordRatioController.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Controllers/WordRatioController.cs
@@ -32,11 +32,10 @@ public class WordRatioController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<WordRatioModel>>> GetAll(int? limit, int? offset)
+    public async Task<ActionResult<IEnumerable<WordRatioModel>>> GetAll(int? limit = 100, int? offset = null)
     {
         try
         {
-            limit ??= 100; // TODO: fix this
             IEnumerable<WordRatioModel> result = await _repository.GetAll(limit, offset);
             return result.Any()
                 ? Ok(result)
@@ -114,9 +113,8 @@ public class WordRatioController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<IEnumerable<WordRatioModel>>> GetByWord(string wordListString, int? limit, int? offset)
+    public async Task<ActionResult<IEnumerable<WordRatioModel>>> GetByWord(string wordListString, int? limit = 100, int? offset = null)
     {
-        limit ??= 100; // TODO: fix this
         List<string> wordList = wordListString.Split(',').ToList();
         try
         {

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/Helpers/DapperSqlHelper.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/Helpers/DapperSqlHelper.cs
@@ -79,7 +79,7 @@ public class DapperSqlHelper : ISqlHelper
         {
             stringBuilder.Append(" limit ").Append(limit);
         }
-        if (offset != null)
+        if (offset is not (0 or null))
         {
             stringBuilder.Append(" offset ").Append(offset);
         }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/Helpers/DapperSqlHelper.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/Helpers/DapperSqlHelper.cs
@@ -67,7 +67,7 @@ public class DapperSqlHelper : ISqlHelper
     /// <inheritdoc/>
     public string GetPaginatedQuery(string sql, int? limit = null, int? offset = null, params string[] orderByColumns)
     {
-        if (limit == null && offset == null || orderByColumns.Length == 0)
+        if (limit is 0 or null && offset == null || orderByColumns.Length == 0)
         {
             return sql;
         }
@@ -75,7 +75,7 @@ public class DapperSqlHelper : ISqlHelper
 
         stringBuilder.Append(" order by ")
             .AppendJoin(',', orderByColumns);
-        if (limit != null)
+        if (limit is not (0 or null))
         {
             stringBuilder.Append(" limit ").Append(limit);
         }

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgDocumentRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgDocumentRepositoryIntegrationTests.cs
@@ -299,7 +299,7 @@ public class NpgDocumentRepositoryIntegrationTests : IntegrationTestBase
     }
 
     [Theory] // The test data contains 5 documents in total.
-    [InlineData(0, null, 0)]
+    [InlineData(0, null, 5)]
     [InlineData(null, null, 5)]
     [InlineData(2, null, 2)]
     [InlineData(2, 4, 1)]

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgWordRatioRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgWordRatioRepositoryIntegrationTests.cs
@@ -180,7 +180,7 @@ public class NpgWordRatioRepositoryIntegrationTests : IntegrationTestBase
     }
 
     [Theory] // The test data contains 410 word_ratios in total.
-    [InlineData(0, null, 0)]
+    [InlineData(0, null, 410)]
     [InlineData(null, null, 410)]
     [InlineData(100, null, 100)]
     [InlineData(500, null, 410)]


### PR DESCRIPTION
Ændret så default limit er 100 hvis den ikke er angivet. Så kommer man ikke til at hente 40 millioner rækker ved en fejl fordi man glemte at sætte et limit. Man sætter `limit=0` for at hente alle rækker. 
Derudover kan man nu også se default-værdien på Swagger.