### PR TITLE
Added ParameterName property to QueryParameter

### DIFF
--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/Helpers/DapperSqlHelper.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/Helpers/DapperSqlHelper.cs
@@ -59,8 +59,8 @@ public class DapperSqlHelper : ISqlHelper
     public string GetParameterString(QueryParameter param)
     {
         string paramString = $"{param.Key} {param.ComparisonOperator} ";
-        if (param.Value is IEnumerable) paramString += $"any(@{param.Key})";
-        else paramString += $"@{param.Key}";
+        if (param.Value is IEnumerable) paramString += $"any(@{param.ParameterName})";
+        else paramString += $"@{param.ParameterName}";
         return paramString;
     }
 

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentRepository.cs
@@ -52,12 +52,12 @@ public class NpgDocumentRepository : IDocumentRepository
         if (parameters.Parameters.Any())
         {
             QueryParameter firstParam = parameters.Parameters.First();
-            args.Add(firstParam.Key, firstParam.Value);
+            args.Add(firstParam.ParameterName, firstParam.Value);
             query.Append(" where " + _sqlHelper.GetParameterString(firstParam));
             foreach (QueryParameter param in parameters.Parameters.Skip(1))
             {
                 query.Append(" and " + _sqlHelper.GetParameterString(param));
-                args.Add(param.Key, param.Value);
+                args.Add(param.ParameterName, param.Value);
             }
         }
         string sql = _sqlHelper.GetPaginatedQuery(query.ToString(), limit, offset, DocumentMap.Id);

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSearchRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSearchRepository.cs
@@ -34,7 +34,7 @@ public class NpgSearchRepository : ISearchRepository
             foreach (QueryParameter param in parameters.Parameters)
             {
                 query.Append(" and " + _sqlHelper.GetParameterString(param));
-                args.Add(param.Key, param.Value);
+                args.Add(param.ParameterName, param.Value);
             }
         }
 

--- a/DocumentDataAPI/DocumentDataAPI/Models/DocumentSearchParameters.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Models/DocumentSearchParameters.cs
@@ -40,13 +40,13 @@ public class DocumentSearchParameters : ISearchParameters
 
     public DocumentSearchParameters AddBeforeDate(DateTime date)
     {
-        Parameters.Add(new QueryParameter(DocumentMap.Date, date, "<="));
+        Parameters.Add(new QueryParameter(DocumentMap.Date, date, "<=", "beforeDate"));
         return this;
     }
 
     public DocumentSearchParameters AddAfterDate(DateTime date)
     {
-        Parameters.Add(new QueryParameter(DocumentMap.Date, date, ">="));
+        Parameters.Add(new QueryParameter(DocumentMap.Date, date, ">=", "afterDate"));
         return this;
     }
 }

--- a/DocumentDataAPI/DocumentDataAPI/Models/QueryParameter.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Models/QueryParameter.cs
@@ -2,18 +2,20 @@ namespace DocumentDataAPI.Models;
 
 public class QueryParameter
 {
+    public readonly string ParameterName;
     public readonly string Key;
     public readonly dynamic Value;
     public readonly string ComparisonOperator;
 
-    public QueryParameter(string key, dynamic value)
+    public QueryParameter(string key, dynamic value, string? parameterName = null)
     {
+        ParameterName = parameterName ?? key;
         Key = key;
         Value = value;
         ComparisonOperator = "=";
     }
 
-    public QueryParameter(string key, DateTime value, string comparisonOperator) : this(key, value)
+    public QueryParameter(string key, DateTime value, string comparisonOperator, string? parameterName = null) : this(key, value, parameterName: parameterName)
     {
         ComparisonOperator = comparisonOperator;
     }


### PR DESCRIPTION
Fixes a bug where adding before and after dates to DocumentSearchParameters gives a query where `document.date >= @date and document.date <= @date`, but should instead give the query `document.date >= @afterDate and document.date <= beforeDate`.