### PR TITLE
Added support for querying different schemas

### DIFF
--- a/DocumentDataAPI/DocumentDataAPI/Data/Deployment/DatabaseDeployHelper.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Deployment/DatabaseDeployHelper.cs
@@ -25,15 +25,21 @@ public class DatabaseDeployHelper
     /// Reads and executes a SQL script file and replaces the schema placeholder with the schema provided in the application settings.
     /// </summary>
     /// <param name="fileName">File path to SQL script.</param>
-    /// <example>deployHelper.ExecuteSqlFromFile("deploy_schema.sql")</example>
-    public void ExecuteSqlFromFile(string fileName)
+    /// <param name="schema">The (optional) schema to execute the SQL script on.</param>
+    /// <example>deployHelper.ExecuteSqlFromFile("deploy_schema.sql", DatabaseOptions.Schema.DocumentData)</example>
+    public void ExecuteSqlFromFile(string fileName, DatabaseOptions.Schema? schema = null)
     {
         string path = Path.Join(Environment.CurrentDirectory, "Data", "Deployment", "Scripts", fileName);
         try
         {
             string script = File.ReadAllText(path)
-                .Replace("${schema}", _databaseOptions.Schema)
                 .Replace("${database}", _databaseOptions.Database);
+
+            if (schema.HasValue)
+            {
+                script = script.Replace("${schema}", _databaseOptions.SchemaToString(schema.Value));
+            }
+            _logger.LogInformation(script);
 
             _logger.LogInformation("Executing script: {Path}", path);
             using IDbConnection connection = _connectionFactory.CreateConnection();

--- a/DocumentDataAPI/DocumentDataAPI/Data/IDbConnectionFactory.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/IDbConnectionFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data;
 
@@ -19,4 +20,10 @@ public interface IDbConnectionFactory
     /// <param name="connectionString">A connection string to the database.</param>
     /// <returns>The connection.</returns>
     IDbConnection CreateConnection(string connectionString);
+
+    /// <summary>
+    /// Adds a search path to the connections, which removes the need to specify a schema in queries.
+    /// </summary>
+    /// <param name="schema">The schema to use for all connections provided by this factory.</param>
+    IDbConnectionFactory WithSchema(DatabaseOptions.Schema schema);
 }

--- a/DocumentDataAPI/DocumentDataAPI/Data/NpgDbConnectionFactory.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/NpgDbConnectionFactory.cs
@@ -1,4 +1,6 @@
 ﻿using System.Data;
+using System.Text;
+using DocumentDataAPI.Options;
 using Npgsql;
 
 namespace DocumentDataAPI.Data;
@@ -8,11 +10,13 @@ namespace DocumentDataAPI.Data;
 /// </summary>
 public class NpgDbConnectionFactory : IDbConnectionFactory
 {
-    private readonly string _connectionString;
+    private string _connectionString;
+    private readonly DatabaseOptions _databaseOptions;
 
-    public NpgDbConnectionFactory(string connectionString)
+    public NpgDbConnectionFactory(DatabaseOptions databaseOptions)
     {
-        _connectionString = connectionString;
+        _databaseOptions = databaseOptions;
+        _connectionString = databaseOptions.ConnectionString;
     }
 
     public IDbConnection CreateConnection()
@@ -23,5 +27,16 @@ public class NpgDbConnectionFactory : IDbConnectionFactory
     public IDbConnection CreateConnection(string connectionString)
     {
         return new NpgsqlConnection(connectionString);
+    }
+
+    public IDbConnectionFactory WithSchema(DatabaseOptions.Schema schema)
+    {
+        _connectionString = new StringBuilder(_connectionString)
+            .Append("SearchPath=")
+            .Append(_databaseOptions.SchemaToString(schema))
+            .Append(';')
+            .ToString();
+
+        return this;
     }
 }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgCategoryRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgCategoryRepository.cs
@@ -3,6 +3,7 @@ using Dapper;
 using DocumentDataAPI.Data.Mappers;
 using DocumentDataAPI.Data.Repositories.Helpers;
 using DocumentDataAPI.Models;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -14,7 +15,7 @@ public class NpgCategoryRepository : ICategoryRepository
 
     public NpgCategoryRepository(IDbConnectionFactory connectionFactory, ILogger<NpgCategoryRepository> logger, ISqlHelper sqlHelper)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
         _sqlHelper = sqlHelper;
     }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentContentRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentContentRepository.cs
@@ -5,6 +5,7 @@ using DocumentDataAPI.Data.Mappers;
 using DocumentDataAPI.Data.Repositories.Helpers;
 using DocumentDataAPI.Exceptions;
 using DocumentDataAPI.Models;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -17,7 +18,7 @@ public class NpgDocumentContentRepository : IDocumentContentRepository
     public NpgDocumentContentRepository(IDbConnectionFactory connectionFactory, ILogger<NpgDocumentContentRepository> logger,
         ISqlHelper sqlHelper)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
         _sqlHelper = sqlHelper;
     }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgDocumentRepository.cs
@@ -5,6 +5,7 @@ using Dapper.Transaction;
 using DocumentDataAPI.Data.Mappers;
 using DocumentDataAPI.Data.Repositories.Helpers;
 using DocumentDataAPI.Models;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -16,7 +17,7 @@ public class NpgDocumentRepository : IDocumentRepository
 
     public NpgDocumentRepository(IDbConnectionFactory connectionFactory, ILogger<NpgDocumentRepository> logger, ISqlHelper sqlHelper)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
         _sqlHelper = sqlHelper;
     }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSearchRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSearchRepository.cs
@@ -6,6 +6,7 @@ using DocumentDataAPI.Data.Algorithms;
 using DocumentDataAPI.Data.Mappers;
 using DocumentDataAPI.Data.Repositories.Helpers;
 using DocumentDataAPI.Models;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -18,7 +19,7 @@ public class NpgSearchRepository : ISearchRepository
 
     public NpgSearchRepository(IDbConnectionFactory connectionFactory, ILogger<NpgSearchRepository> logger, IRelevanceFunction relevanceFunction, ISqlHelper sqlHelper)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
         _relevanceFunction = relevanceFunction;
         _sqlHelper = sqlHelper;

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSimilarDocumentRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSimilarDocumentRepository.cs
@@ -5,6 +5,7 @@ using DocumentDataAPI.Data.Repositories.Helpers;
 using DocumentDataAPI.Exceptions;
 using DocumentDataAPI.Models;
 using System.Data;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -15,7 +16,7 @@ public class NpgSimilarDocumentRepository : ISimilarDocumentRepository
     private readonly ISqlHelper _sqlHelper;
     public NpgSimilarDocumentRepository(IDbConnectionFactory connectionFactory, ILogger<NpgSimilarDocumentRepository> logger, ISqlHelper sqlHelper)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
         _sqlHelper = sqlHelper;
     }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSourceRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgSourceRepository.cs
@@ -3,6 +3,7 @@ using Dapper;
 using DocumentDataAPI.Data.Mappers;
 using DocumentDataAPI.Data.Repositories.Helpers;
 using DocumentDataAPI.Models;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -14,7 +15,7 @@ public class NpgSourceRepository : ISourceRepository
 
     public NpgSourceRepository(IDbConnectionFactory connectionFactory, ILogger<NpgSourceRepository> logger, ISqlHelper sqlHelper)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
         _sqlHelper = sqlHelper;
     }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgWordRatioRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgWordRatioRepository.cs
@@ -5,6 +5,7 @@ using DocumentDataAPI.Data.Mappers;
 using DocumentDataAPI.Data.Repositories.Helpers;
 using DocumentDataAPI.Exceptions;
 using DocumentDataAPI.Models;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -16,7 +17,7 @@ public class NpgWordRatioRepository : IWordRatioRepository
 
     public NpgWordRatioRepository(IDbConnectionFactory connectionFactory, ILogger<NpgWordRatioRepository> logger, ISqlHelper sqlHelper)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
         _sqlHelper = sqlHelper;
     }

--- a/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgWordRelevanceRepository.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Data/Repositories/NpgWordRelevanceRepository.cs
@@ -2,6 +2,7 @@ using System.Data;
 using Dapper;
 using DocumentDataAPI.Data.Mappers;
 using DocumentDataAPI.Data.Repositories.Helpers;
+using DocumentDataAPI.Options;
 
 namespace DocumentDataAPI.Data.Repositories;
 
@@ -12,7 +13,7 @@ public class NpgWordRelevanceRepository : IWordRelevanceRepository
 
     public NpgWordRelevanceRepository(IDbConnectionFactory connectionFactory, ILogger<NpgWordRelevanceRepository> logger)
     {
-        _connectionFactory = connectionFactory;
+        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
         _logger = logger;
     }
 

--- a/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
+++ b/DocumentDataAPI/DocumentDataAPI/Options/DatabaseOptions.cs
@@ -6,11 +6,16 @@ namespace DocumentDataAPI.Options;
 /// </summary>
 public class DatabaseOptions
 {
+    public enum Schema
+    {
+        DocumentData
+    }
+
     public const string Key = "Database";
     public string Host { get; set; } = string.Empty;
     public int Port { get; set; }
     public string Database { get; set; } = string.Empty;
-    public string Schema { get; set; } = string.Empty;
+    public string DocumentDataSchema { get; set; } = string.Empty;
     public string Username { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
 
@@ -28,6 +33,14 @@ public class DatabaseOptions
         "Password=" + Password + ";" +
         "Host=" + Host + ";" +
         "Port=" + Port + ";" +
-        "Database=" + Database + ";" +
-        "SearchPath=" + Schema + ";";
+        "Database=" + Database + ";";
+
+    public string SchemaToString(Schema schema)
+    {
+        return schema switch
+        {
+            Schema.DocumentData => DocumentDataSchema,
+            _ => string.Empty
+        };
+    }
 }

--- a/DocumentDataAPI/DocumentDataAPI/appsettings.json
+++ b/DocumentDataAPI/DocumentDataAPI/appsettings.json
@@ -10,7 +10,7 @@
     "Host": "",
     "Port": "0000",
     "Database": "",
-    "Schema": "",
+    "DocumentDataSchema": "",
     "Username": "",
     "Password": ""
   },

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgCategoryRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgCategoryRepositoryIntegrationTests.cs
@@ -16,7 +16,7 @@ public class NpgCategoryRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgCategoryRepositoryIntegrationTests()
     {
-        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions.ConnectionString);
+        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions);
         _logger = new Logger<NpgCategoryRepository>(new NullLoggerFactory());
         _sqlHelper = new DapperSqlHelper(Configuration);
     }

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgDocumentContentRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgDocumentContentRepositoryIntegrationTests.cs
@@ -16,7 +16,7 @@ public class NpgDocumentContentRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgDocumentContentRepositoryIntegrationTests()
     {
-        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions.ConnectionString);
+        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions);
         _logger = new Logger<NpgDocumentContentRepository>(new NullLoggerFactory());
         _sqlHelper = new DapperSqlHelper(Configuration);
     }

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgDocumentRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgDocumentRepositoryIntegrationTests.cs
@@ -15,7 +15,7 @@ public class NpgDocumentRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgDocumentRepositoryIntegrationTests()
     {
-        NpgDbConnectionFactory connectionFactory = new(DatabaseOptions.ConnectionString);
+        NpgDbConnectionFactory connectionFactory = new(DatabaseOptions);
         ILogger<NpgDocumentRepository> logger = new Logger<NpgDocumentRepository>(new NullLoggerFactory());
         _repository = new NpgDocumentRepository(connectionFactory, logger, new DapperSqlHelper(Configuration));
     }

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgSearchRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgSearchRepositoryIntegrationTests.cs
@@ -15,7 +15,7 @@ public class NpgSearchRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgSearchRepositoryIntegrationTests()
     {
-        NpgDbConnectionFactory connectionFactory = new(DatabaseOptions.ConnectionString);
+        NpgDbConnectionFactory connectionFactory = new(DatabaseOptions);
         ILogger<NpgSearchRepository> logger = new Logger<NpgSearchRepository>(new NullLoggerFactory());
         IRelevanceFunction relevanceFunction = new CosineSimilarityCalculator();
         _repository = new NpgSearchRepository(connectionFactory, logger, relevanceFunction, new DapperSqlHelper(Configuration));

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgSimilarDocumentRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgSimilarDocumentRepositoryIntegrationTests.cs
@@ -14,7 +14,7 @@ public class NpgSimilarDocumentRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgSimilarDocumentRepositoryIntegrationTests()
     {
-        NpgDbConnectionFactory connectionFactory = new(DatabaseOptions.ConnectionString);
+        NpgDbConnectionFactory connectionFactory = new(DatabaseOptions);
         ILogger<NpgSimilarDocumentRepository> logger = new Logger<NpgSimilarDocumentRepository>(new NullLoggerFactory());
         _repository = new NpgSimilarDocumentRepository(connectionFactory, logger, new DapperSqlHelper(Configuration));
     }
@@ -59,7 +59,7 @@ public class NpgSimilarDocumentRepositoryIntegrationTests : IntegrationTestBase
         IEnumerable<SimilarDocumentModel> actual = await _repository.Get(mainDocumentId);
 
         // Assert
-        actual.Any(item => item.MainDocumentId == similarDocument.MainDocumentId 
+        actual.Any(item => item.MainDocumentId == similarDocument.MainDocumentId
             && item.SimilarDocumentId == similarDocument.SimilarDocumentId).Should()
             .BeTrue("because id is a list of main document ids that had similar docs added");
     }

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgSourceRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgSourceRepositoryIntegrationTests.cs
@@ -16,7 +16,7 @@ public class NpgSourceRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgSourceRepositoryIntegrationTests()
     {
-        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions.ConnectionString);
+        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions);
         _logger = new Logger<NpgSourceRepository>(new NullLoggerFactory());
         _sqlHelper = new DapperSqlHelper(Configuration);
     }

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgWordRatioRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgWordRatioRepositoryIntegrationTests.cs
@@ -16,7 +16,7 @@ public class NpgWordRatioRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgWordRatioRepositoryIntegrationTests()
     {
-        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions.ConnectionString);
+        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions);
         _logger = new Logger<NpgWordRatioRepository>(new NullLoggerFactory());
         _sqlHelper = new DapperSqlHelper(Configuration);
     }

--- a/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgWordRelevanceRepositoryIntegrationTests.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/Data/Repositories/NpgWordRelevanceRepositoryIntegrationTests.cs
@@ -17,7 +17,7 @@ public class NpgWordRelevanceRepositoryIntegrationTests : IntegrationTestBase
 
     public NpgWordRelevanceRepositoryIntegrationTests()
     {
-        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions.ConnectionString);
+        _connectionFactory = new NpgDbConnectionFactory(DatabaseOptions);
         _relevanceLogger = new Logger<NpgWordRelevanceRepository>(new NullLoggerFactory());
         _ratioLogger = new Logger<NpgWordRatioRepository>(new NullLoggerFactory());
         _sqlHelper = new DapperSqlHelper(Configuration);

--- a/DocumentDataAPI/DocumentDataAPITests/IntegrationTestBase.cs
+++ b/DocumentDataAPI/DocumentDataAPITests/IntegrationTestBase.cs
@@ -34,11 +34,11 @@ public abstract class IntegrationTestBase : IDisposable
 
     private void DeployDatabaseWithTestData()
     {
-        IDbConnectionFactory connectionFactory = new NpgDbConnectionFactory(DatabaseOptions.ConnectionString);
+        IDbConnectionFactory connectionFactory = new NpgDbConnectionFactory(DatabaseOptions);
         DatabaseDeployHelper deployHelper =
             new(Mock.Of<ILogger<DatabaseDeployHelper>>(), Configuration, connectionFactory);
-        deployHelper.ExecuteSqlFromFile("deploy_schema.sql");
-        deployHelper.ExecuteSqlFromFile("populate_tables.sql");
+        deployHelper.ExecuteSqlFromFile("deploy_schema.sql", DatabaseOptions.Schema.DocumentData);
+        deployHelper.ExecuteSqlFromFile("populate_tables.sql", DatabaseOptions.Schema.DocumentData);
     }
 
     public void Dispose()


### PR DESCRIPTION
Det er nu muligt at bruge forskellige schemas i repositories. Man tilføjer et nyt schema således:

1. Tilføj schemaet til `appsettings*.json`
2. Tilføj properties til schemaet i `DatabaseOptions.cs`, og en mapping til funktionen `DatabaseOptions.SchemaToString(schema)`
3. Hvis I vil have schemaet deployet med kommandolinjen `deploy=true`, så tilføj jeres deploy-script i `Program.cs` omkring linje 99.
4. I repositories kan man specificere et schema på `IDbConnectionFactory` som vist her:
```csharp
    public NpgSourceRepository(IDbConnectionFactory connectionFactory, ILogger<NpgSourceRepository> logger, ISqlHelper sqlHelper)
    {
        _connectionFactory = connectionFactory.WithSchema(DatabaseOptions.Schema.DocumentData);
    ...
```
Hvis der er tvivl om noget så tag udgangspunkt i hvordan det er gjort med `document_data` schemaet.